### PR TITLE
update run command to runBREC()

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ install_github("ymansour21/BREC")
 library(Brec)
 library(shiny) 
 # Launch Brec graphical interface in your default internet browser
-runApp("shinyApp/Brec_dashboard.R", launch.browser = TRUE)
+runBREC()
 ```
 
 Further details and examples will be available soon :)


### PR DESCRIPTION
Referring to the run function defined here: https://github.com/ymansour21/BREC/blob/b36da24a57cfc24489805857a6e3ca3a58348fc3/R/runBREC.R#L3

I believe this function needs to be explicitly exported
